### PR TITLE
Move extend window by prepare phase length

### DIFF
--- a/src/pages/stacking/self-service-extend/utils.ts
+++ b/src/pages/stacking/self-service-extend/utils.ts
@@ -72,7 +72,8 @@ export function nextExtendWindow(burnBlockHeight: number, poxInfo: PoxInfo) {
   const blocksUntilNextExtendWindow =
     poxInfo.reward_cycle_length -
     ((burnBlockHeight - poxInfo.first_burnchain_block_height + halfTheCycle - 1) %
-      poxInfo.reward_cycle_length);
+      poxInfo.reward_cycle_length) -
+    poxInfo.prepare_cycle_length;
   const blocksUntilExtendWindowEnds = blocksUntilNextExtendWindow - halfTheCycle - 1;
   const tooEarly = blocksUntilNextExtendWindow < halfTheCycle;
   const tooLate = blocksUntilExtendWindowEnds <= 0;


### PR DESCRIPTION
This PR
* moves the extend window by the length of the prepare phase (100 blocks for mainnet)
* partly solves #130 

This is now in line with stacking.club
![image](https://github.com/hirosystems/lockstacks/assets/1449049/a1508e8f-0d14-4d13-9b24-3013bceffd5a)

stacking.club
![image](https://github.com/hirosystems/lockstacks/assets/1449049/fe7fad7d-a6fb-40a1-ac4a-83afe00256be)
