### PR TITLE
Fix NaN in pooled stacking info

### DIFF
--- a/src/pages/stacking/pooled-stacking-info/pooled-stacking-info.tsx
+++ b/src/pages/stacking/pooled-stacking-info/pooled-stacking-info.tsx
@@ -92,7 +92,7 @@ function PooledStackingInfoLayout({ client }: CardLayoutProps) {
 
   const isExpired =
     delegationStatusQuery.data.delegated &&
-    delegationStatusQuery.data.details.until_burn_ht &&
+    delegationStatusQuery.data.details.until_burn_ht !== undefined &&
     !Number.isNaN(delegationStatusQuery.data.details.until_burn_ht) &&
     delegationStatusQuery.data.details.until_burn_ht < getCoreInfoQuery.data.burn_block_height;
 


### PR DESCRIPTION
This PR
* fixes how until_burn_ht is checked for undefined value
* fixes #139 

![image](https://github.com/hirosystems/lockstacks/assets/1449049/7dd5ca43-7a20-45e9-b5c7-79dbfa0b27af)
