### PR TITLE
Use indefinite duration as default for 1-cycle pools

### DIFF
--- a/src/pages/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
+++ b/src/pages/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
@@ -24,6 +24,14 @@ export function ChoosePoolingAmount() {
     <Step title="Amount">
       <Description>
         <Text>Choose how much you&apos;ll pool. Your pool may require a minimum.</Text>
+        <Text>
+          The pooled amount can be higher than your current balance to allow the pool to stack more
+          in the future.
+        </Text>
+        <Text>
+          The pool may stack less than the delegated amount to leave some change to pay for transaction
+          fees.
+        </Text>
       </Description>
 
       <Box position="relative" maxWidth="400px">

--- a/src/pages/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
+++ b/src/pages/stacking/start-pooled-stacking/components/choose-pooling-amount.tsx
@@ -29,8 +29,8 @@ export function ChoosePoolingAmount() {
           in the future.
         </Text>
         <Text>
-          The pool may stack less than the delegated amount to leave some change to pay for transaction
-          fees.
+          The pool may stack less than the delegated amount to leave some change to pay for
+          transaction fees.
         </Text>
       </Description>
 

--- a/src/pages/stacking/start-pooled-stacking/components/choose-pooling-duration.tsx
+++ b/src/pages/stacking/start-pooled-stacking/components/choose-pooling-duration.tsx
@@ -1,14 +1,18 @@
-import { Box, Flex, Stack, Text, color } from '@stacks/ui';
+import { useState } from 'react';
+
+import { Box, Button, Flex, Stack, Text, color } from '@stacks/ui';
 import { useField } from 'formik';
 
 import { ErrorLabel } from '@components/error-label';
 import { ErrorText } from '@components/error-text';
 
 import { Description, Step } from '../../components/stacking-form-step';
+import { PoolName } from '../types-preset-pools';
 import { DurationCyclesField } from './duration-cycles-field';
 import { DurationSelectItem } from './duration-select-item';
 import { IndefiniteStackingIcon } from './indefinite-stacking-icon';
 import { LimitedStackingIcon } from './limited-stacking-icon';
+import { pools } from './preset-pools';
 
 function RecommendedFor({ children }: { children?: React.ReactNode }) {
   return (
@@ -35,11 +39,39 @@ function RecommendedFor({ children }: { children?: React.ReactNode }) {
 }
 
 export function ChoosePoolingDuration() {
+  const [fieldPoolName] = useField<PoolName>('poolName');
   const [fieldNumberOfCycles] = useField('numberOfCycles');
   const [fieldDelegationDurationType, metaDelegationDurationType, helpersDelegationDurationType] =
     useField('delegationDurationType');
+  const [customDuration, setCustomDuration] = useState(false);
 
-  return (
+  const duration = pools[fieldPoolName.value]?.duration;
+  return !customDuration && duration > 0 ? (
+    <Step title="Duration">
+      <Description>
+        <Text>
+          The pool looks your STX for {duration} cycle{duration > 1 ? 's' : ''} at the time. You can
+          revoke the pool permission at any time and your STX will be unlocked after the end of the
+          next cycle.
+        </Text>
+        <Text>
+          By default, you will be part of the pool until you revoke (indefinite duration). You can
+          set a limit to leave the pool automatically{' '}
+          <Button
+            variant="link"
+            type="button"
+            onClick={() => {
+              helpersDelegationDurationType.setValue('limited');
+              setCustomDuration(true);
+            }}
+          >
+            here
+          </Button>
+          .
+        </Text>
+      </Description>
+    </Step>
+  ) : (
     <Step title="Duration">
       <Description>
         <Text>
@@ -82,6 +114,22 @@ export function ChoosePoolingDuration() {
             Users who want to guarantee funds are not locked beyond a certain period.
           </RecommendedFor>
         </DurationSelectItem>
+        {duration > 0 && (
+          <Text>
+            Reset to default indefinite duration{' '}
+            <Button
+              variant="link"
+              type="button"
+              onClick={() => {
+                helpersDelegationDurationType.setValue('indefinite');
+                setCustomDuration(false);
+              }}
+            >
+              here
+            </Button>
+            .
+          </Text>
+        )}
       </Stack>
 
       {metaDelegationDurationType.touched && metaDelegationDurationType.error && (

--- a/src/pages/stacking/start-pooled-stacking/components/choose-pooling-pool.tsx
+++ b/src/pages/stacking/start-pooled-stacking/components/choose-pooling-pool.tsx
@@ -13,7 +13,9 @@ interface ChoosePoolingPoolProps {
 }
 export function ChoosePoolingPool({ onPoolChange }: ChoosePoolingPoolProps) {
   const [fieldPoolName, , helpersPoolName] = useField('poolName');
+  const [, , helpersDelegationDurationType] = useField('delegationDurationType');
   const onChange = (poolName: PoolName) => {
+    helpersDelegationDurationType.setValue(pools[poolName].duration > 0 ? 'indefinite' : 'limited');
     helpersPoolName.setValue(poolName);
     onPoolChange(poolName);
   };


### PR DESCRIPTION
This PR
* replaces the duration selection form with a default text
* fixes #30 
* fixes #140 

Screencast: https://www.loom.com/share/63a53556b7d54ca1a112ef1ef7707b5a?sid=8dd43fca-f788-4c56-ae3b-d9ad4f515d7b