### PR TITLE
feat: use new pox-4 pool contracts

### DIFF
--- a/src/pages/stacking/start-pooled-stacking/components/preset-pools.tsx
+++ b/src/pages/stacking/start-pooled-stacking/components/preset-pools.tsx
@@ -21,7 +21,7 @@ export const pools = {
       ' ' +
       'Locked STX will unlock 1 day after the end of the cycle.',
     duration: 1,
-    website: 'https://pool.friedger.de',
+    website: 'https://fastpool.org',
     payoutMethod: PayoutMethod.STX,
     poolAddress: {
       [NetworkInstance.mainnet]:
@@ -35,7 +35,7 @@ export const pools = {
     minimumDelegationAmount: 40_000_000,
     icon: <PoolIcon src="/32x32_FastPool.png" />,
     allowCustomRewardAddress: false,
-    disabled: true,
+    disabled: false,
   },
 
   PlanBetter: {
@@ -53,7 +53,7 @@ export const pools = {
     minimumDelegationAmount: 200_000_000,
     icon: <PoolIcon src="/32x32_PlanBetter.png" />,
     allowCustomRewardAddress: false, // only for ledger users
-    disabled: true,
+    disabled: false,
   },
 
   Xverse: {
@@ -72,7 +72,7 @@ export const pools = {
     minimumDelegationAmount: 100_000_000,
     icon: <PoolIcon src="/32x32_Xverse.png" />,
     allowCustomRewardAddress: true,
-    disabled: true,
+    disabled: false,
   },
   'Custom Pool': {
     name: PoolName.CustomPool,

--- a/src/pages/stacking/start-pooled-stacking/types-preset-pools.ts
+++ b/src/pages/stacking/start-pooled-stacking/types-preset-pools.ts
@@ -22,25 +22,23 @@ export const NetworkInstanceToPoxContractMap = {
   [NetworkInstance.devnet]: {
     [PoxContractName.Pox3]: 'ST000000000000000000002AMW42H.pox-3',
     [PoxContractName.Pox4]: 'ST000000000000000000002AMW42H.pox-4',
-    [PoxContractName.WrapperOneCycle]:
-      'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox-pools-1-cycle',
+    [PoxContractName.WrapperOneCycle]: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox4-pools',
     [PoxContractName.WrapperFastPool]:
-      'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox-pool-self-service',
+      'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox4-self-service',
   },
   [NetworkInstance.testnet]: {
     [PoxContractName.Pox3]: 'ST000000000000000000002AMW42H.pox-3',
     [PoxContractName.Pox4]: 'ST000000000000000000002AMW42H.pox-4',
-    [PoxContractName.WrapperOneCycle]:
-      'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW.pox-pools-1-cycle-v2',
+    [PoxContractName.WrapperOneCycle]: 'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW.pox4-pools',
     [PoxContractName.WrapperFastPool]:
-      'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW.pox-pool-self-service-v2',
+      'ST2PABAF9FTAJYNFZH93XENAJ8FVY99RRM4DF2YCW.pox4-self-service',
   },
   [NetworkInstance.mainnet]: {
     [PoxContractName.Pox3]: 'SP000000000000000000002Q6VF78.pox-3',
     [PoxContractName.Pox4]: 'SP000000000000000000002Q6VF78.pox-4',
-    [PoxContractName.WrapperOneCycle]:
-      'SP001SFSMC2ZY76PD4M68P3WGX154XCH7NE3TYMX.pox-pools-1-cycle-v2',
-    [PoxContractName.WrapperFastPool]: 'SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP.pox-fast-pool-v2',
+    [PoxContractName.WrapperOneCycle]: 'SP001SFSMC2ZY76PD4M68P3WGX154XCH7NE3TYMX.pox4-pools',
+    [PoxContractName.WrapperFastPool]:
+      'SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP.pox4-fast-pool-v3',
   },
 } as const;
 


### PR DESCRIPTION
This PR
* updates the pools to the new pox-4 contracts
* enables the public pools again

The new contracts are 
* SP001SFSMC2ZY76PD4M68P3WGX154XCH7NE3TYMX.pox4-pools : https://explorer.hiro.so/txid/0x9c4ac9d9d44ef476c3639ccd849d499a798c4785216b1cbb74fa758a2b52dfd5?chain=mainnet
* SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP.pox4-fast-pool-v3: https://explorer.hiro.so/txid/0x4abafe07d549148d881e2c808ba9dde8bf1dcb82478f7a482b569e631bc0607b?chain=mainnet

The fast pool contract is initialized here: https://explorer.hiro.so/txid/0x6168c9da3fd90f7060bcd0089ad0d1024aae3c3a74f18e2da7d037e353ed3c0f?chain=mainnet