### PR TITLE
Validate reward cycle in signatures

### DIFF
--- a/src/pages/stacking/signer/generate-signature/utils.ts
+++ b/src/pages/stacking/signer/generate-signature/utils.ts
@@ -49,6 +49,17 @@ export function createValidationSchema({
           }
           return true;
         }
+      )
+      .test(
+        'is-now-for-solo-stacking',
+        'Reward cycle must be the current cycle for solo stacking signatures',
+        function (rewardCycle) {
+          const topic = this.parent.topic;
+          if (topic === 'stack-stx' || topic === 'stack-extend' || topic === 'stack-increase') {
+            return rewardCycle === currentCycle;
+          }
+          return true;
+        }
       ),
     authId: yup
       .number()

--- a/src/pages/stacking/start-direct-stacking/start-direct-stacking.tsx
+++ b/src/pages/stacking/start-direct-stacking/start-direct-stacking.tsx
@@ -96,6 +96,7 @@ function StartDirectStackingLayout({ client }: StartDirectStackingLayoutProps) {
     transactionFeeUStx,
     availableBalanceUStx: intToBigInt(getAccountExtendedBalancesQuery.data.stx.balance, false),
     network,
+    rewardCycleId: getPoxInfoQuery.data.current_cycle.id,
   });
   const handleSubmit = createHandleSubmit({
     client,


### PR DESCRIPTION
When solo stacking, the `reward-cycle` used in a signature must equal the current reward cycle.

This PR adds two things:

- It shows a validation error when generating the signature if solo stacking and reward cycle is in the future
- It shows a validation error on the stack-stx page if the user pasted in JSON that has an incorrect reward cycle