### PR TITLE
fix: prevent 0x input in signer details

### DIFF
--- a/src/pages/stacking/pool-admin/stack-aggregation-commit/components/signer-input.tsx
+++ b/src/pages/stacking/pool-admin/stack-aggregation-commit/components/signer-input.tsx
@@ -15,13 +15,25 @@ interface Props {
 }
 
 export function SignerInput({ title, text, fieldName, placeholder }: Props) {
-  const [field, meta] = useField(fieldName);
+  const [field, meta, helpers] = useField(fieldName);
   return (
     <>
       <Title fontSize="20px">{title}</Title>
       {text}
       <Box position="relative" maxWidth="400px">
-        <Input {...field} mt={'loose'} placeholder={placeholder} />
+        <Input
+          {...field}
+          mt={'loose'}
+          onChange={e => {
+            if ('value' in e.target) {
+              const { value } = e.target;
+              if (!value) return field.onChange(e);
+              return helpers.setValue(value.replaceAll('0x', ''));
+            }
+            return field.onChange(e);
+          }}
+          placeholder={placeholder}
+        />
         {meta.touched && meta.error && (
           <ErrorLabel>
             <ErrorText>{meta.error}</ErrorText>

--- a/src/utils/validators/hex-string-validator.ts
+++ b/src/utils/validators/hex-string-validator.ts
@@ -1,7 +1,9 @@
 import * as yup from 'yup';
 
 export function hexStringSchema() {
-  return yup.string().transform((hex: string) => {
-    return `${hex.replaceAll('0x', '')}`;
+  return yup.string().test('no-0x', 'Value may not start with 0x', value => {
+    if (typeof value !== 'string') return true;
+    if (!value.length) return true;
+    return !value.startsWith('0x');
   });
 }


### PR DESCRIPTION
It's normal for users to enter `0x...` when they're inputting signer details manually, but this leads to a bug when submitting the forms.

This PR changes it so that `0x` is removed from signer details inputs automatically.