### PR TITLE
fix: allow p2wsh addresses

### DIFF
--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -22,7 +22,7 @@ export const UI_IMPOSED_MAX_STACKING_AMOUNT_USTX = stxToMicroStx(10_000_000_000)
 
 export const STACKING_CONTRACT_CALL_TX_BYTES = 260;
 
-export const SUPPORTED_BTC_ADDRESS_FORMATS = ['p2pkh', 'p2sh', 'p2wpkh', 'p2tr'] as const;
+export const SUPPORTED_BTC_ADDRESS_FORMATS = ['p2pkh', 'p2sh', 'p2wpkh', 'p2tr', 'p2wsh'] as const;
 
 export const FEE_RATE = 400;
 

--- a/src/pages/stacking/utils/calc-stacking-buffer.spec.ts
+++ b/src/pages/stacking/utils/calc-stacking-buffer.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { stxToMicroStx } from '../../../utils/unit-convert';
 import { calculateRewardSlots } from './calc-stacking-buffer';
 

--- a/src/utils/stacking.spec.ts
+++ b/src/utils/stacking.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { convertPoxAddressToBtc } from './stacking';
 
 describe(convertPoxAddressToBtc.name, () => {

--- a/src/utils/tx-utils.spec.ts
+++ b/src/utils/tx-utils.spec.ts
@@ -1,4 +1,5 @@
 import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
+import { describe, expect, test } from 'vitest';
 
 import { sumTxsTotalSpentByAddress } from './tx-utils';
 

--- a/src/utils/validators/btc-address-validator.spec.ts
+++ b/src/utils/validators/btc-address-validator.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+
+import { validateBtcAddress } from '@utils/validators/btc-address-validator';
+
+test('validation p2wsh', () => {
+  const addr = 'bc1qun60xhsf28d3hcuxlxxg59e3er7vvgzvwvg8pkw4scc7gk3mjkcsa5fkgu';
+  const validation = validateBtcAddress(addr, 'mainnet');
+  expect(validation).toEqual(true);
+});


### PR DESCRIPTION
P2WSH wasn't allowed in BTC address fields, but it is allowed in the PoX contract.